### PR TITLE
Pi Zero Performance improvements

### DIFF
--- a/scenes/flight/flight_scene.py
+++ b/scenes/flight/flight_scene.py
@@ -304,13 +304,14 @@ class FlightScene:
         flight = self.flights[self.flight_index]
         origin = flight.origin
         destination = flight.destination
+        cfg = Config.instance()
 
         route_changed = origin != self.last_origin or destination != self.last_dest
         if route_changed:
             self.journey_label.reset()
             self.last_origin = origin
             self.last_dest = destination
-        else:
+        elif cfg.airport_display_style == 0:
             # No need to redraw journey when the route hasn't changed
             return
 

--- a/scenes/flight/flight_scene.py
+++ b/scenes/flight/flight_scene.py
@@ -310,6 +310,9 @@ class FlightScene:
             self.journey_label.reset()
             self.last_origin = origin
             self.last_dest = destination
+        else:
+            # No need to redraw journey when the route hasn't changed
+            return
 
         # Journey text starts after the icon (1px gap) when an icon was
         # drawn; otherwise starts at x=1 (the original margin).


### PR DESCRIPTION
# Pull Request

## Summary
This makes a drawing change in the flight scene to only draw the journey data when it changes (new flight or cycled through multiple flights). This improves display quality on slow hardware.

Pi Zero's need a little more work to eliminate all flicker/ghosting,  something like a configuration option for enabling hardware pulsing for `rgbmatrix`. However I would like some feedback before making commits/PRs for it

## Motivation
On slower hardware like the Pi Zero W, there is a lot of flickering on the journey (source/destination) and flight detail scroller. This helps shorten draw time by only updating the top row when needed

## Changes
In `flight_scene.py` there is a return added when `route_changed` is False.

## Hardware Tested On
- **Raspberry Pi model:** Pi Zero W
- **OS:** Raspberry Pi OS Trixie
- **Testing Steps:** Waited for single and multiple flights, made sure journey data still cycles properly
- Also tested with the simulator feature and ran tests

## Checklist
- [X] Tests pass
- [X] Linter passes
- [ ] Documentation updated
- [X] No secrets committed
- [X] Tested on actual hardware